### PR TITLE
feat: configurable sync interval with disable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,34 @@ To enable hybrid search (keyword + semantic), run `/session-embeddings-setup` in
 
 Config is stored at `~/.pi/session-search/config.json`. The `embedder` field is optional — omit it for FTS5-only mode.
 
+### Sync configuration
+
+By default, the session index re-syncs automatically every 5 minutes after startup.
+Fine-tune or disable this behaviour via the `sync` field:
+
+```json
+{
+  "sync": {
+    "interval": 900000,
+    "initialDelay": 2000,
+    "disableForChild": true
+  }
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `interval` | number | `300000` (5 min) | Milliseconds between periodic re-syncs. Set to `-1` to disable periodic sync entirely (initial startup sync still runs). Any other non-positive value falls back to 5 min with a warning. |
+| `initialDelay` | number | `0` (immediate) | Milliseconds to wait before the first startup sync. Set to `-1` to skip the initial sync entirely. Set to a positive value to defer startup sync (e.g., `2000` to let pi finish booting first). |
+| `disableForChild` | boolean | `false` | When `true`, automatically disables both initial and periodic sync if the pi process is detected as a subagent child (`PI_SUBAGENT_DEPTH > 0`) or running non-interactively (`!process.stdin.isTTY`). Useful for CI/CD pipelines and nested agent workflows. |
+
+**Common configurations:**
+
+- **Disable all sync**: `{ "sync": { "interval": -1, "initialDelay": -1 } }`
+- **Slower sync cadence**: `{ "sync": { "interval": 900000 } }` (every 15 min)
+- **Defer startup sync**: `{ "sync": { "initialDelay": 3000 } }` (wait 3 seconds)
+- **Auto-disable in children**: `{ "sync": { "disableForChild": true } }`
+
 ### OpenAI-compatible providers
 
 Many embedding providers expose an OpenAI-compatible `/v1/embeddings` endpoint. Use `"type": "openai-compatible"` with a `baseUrl`:
@@ -123,7 +151,7 @@ Tested against a 2,159-session corpus: hybrid surfaces **75% more relevant docum
 ### Indexing
 
 - Index stored at `~/.pi/session-search/index/`
-- Incremental sync on startup + every 5 minutes
+- Incremental sync on startup + configurable periodic re-sync (default 5 min)
 - Two separate SQLite DBs: `sessions-fts.db` (pure-FTS mode) and `hybrid-fts.db` (side-car for embedder mode)
 - Switching modes doesn't corrupt state
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-session-search",
-  "version": "1.2.1",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-session-search",
-      "version": "1.2.1",
+      "version": "1.3.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.5.0",
-        "tsx": "^4.19.0"
+        "tsx": "^4.19.0",
+        "typescript": "^6.0.3"
       },
       "optionalDependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.700.0",
@@ -4995,6 +4996,20 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/uint8array-extras": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
-    "tsx": "^4.19.0"
+    "tsx": "^4.19.0",
+    "typescript": "^6.0.3"
   },
   "scripts": {
     "test": "node --test --import tsx src/**/*.test.ts"

--- a/src/__tests__/config-localpath.test.ts
+++ b/src/__tests__/config-localpath.test.ts
@@ -410,4 +410,25 @@ describe("config.localPath resolution", () => {
     assert.equal(cfg.sync?.initialDelay, -1);
     assert.equal(cfg.sync?.disableForChild, true);
   });
+
+  it("loadConfig: disableForChild alone (no other sync fields) still produces sync node", () => {
+    writeProjectSettings({ "pi-session-search": { localPath: tmpLocal } });
+    saveConfig({ sync: { disableForChild: true } }, tmpProject);
+    const cfg = loadConfig(tmpProject);
+    assert.ok(cfg);
+    assert.ok(cfg.sync);
+    assert.equal(cfg.sync!.disableForChild, true);
+    assert.equal(cfg.sync!.interval, undefined);
+    assert.equal(cfg.sync!.initialDelay, undefined);
+  });
+
+  it("loadConfig: disableForChild + interval without initialDelay", () => {
+    writeProjectSettings({ "pi-session-search": { localPath: tmpLocal } });
+    saveConfig({ sync: { interval: 900_000, disableForChild: true } }, tmpProject);
+    const cfg = loadConfig(tmpProject);
+    assert.ok(cfg);
+    assert.equal(cfg.sync?.interval, 900_000);
+    assert.equal(cfg.sync?.disableForChild, true);
+    assert.equal(cfg.sync?.initialDelay, undefined);
+  });
 });

--- a/src/__tests__/config-localpath.test.ts
+++ b/src/__tests__/config-localpath.test.ts
@@ -375,4 +375,39 @@ describe("config.localPath resolution", () => {
     assert.equal(cfg.sync!.initialDelay, 5_000);
     assert.equal(cfg.sync!.interval, undefined);
   });
+
+  it("loadConfig: disableForChild=true is passed through", () => {
+    writeProjectSettings({ "pi-session-search": { localPath: tmpLocal } });
+    saveConfig({ sync: { disableForChild: true } }, tmpProject);
+    const cfg = loadConfig(tmpProject);
+    assert.ok(cfg);
+    assert.equal(cfg.sync?.disableForChild, true);
+  });
+
+  it("loadConfig: disableForChild=false is passed through", () => {
+    writeProjectSettings({ "pi-session-search": { localPath: tmpLocal } });
+    saveConfig({ sync: { disableForChild: false } }, tmpProject);
+    const cfg = loadConfig(tmpProject);
+    assert.ok(cfg);
+    assert.equal(cfg.sync?.disableForChild, false);
+  });
+
+  it("loadConfig: disableForChild ignored when non-boolean", () => {
+    writeProjectSettings({ "pi-session-search": { localPath: tmpLocal } });
+    const configFile = getConfigPath(tmpProject);
+    fs.writeFileSync(configFile, JSON.stringify({ sync: { disableForChild: "yes" } }), "utf-8");
+    const cfg = loadConfig(tmpProject);
+    assert.ok(cfg);
+    assert.equal(cfg.sync?.disableForChild, undefined);
+  });
+
+  it("loadConfig: all three sync fields loaded together", () => {
+    writeProjectSettings({ "pi-session-search": { localPath: tmpLocal } });
+    saveConfig({ sync: { interval: -1, initialDelay: -1, disableForChild: true } }, tmpProject);
+    const cfg = loadConfig(tmpProject);
+    assert.ok(cfg);
+    assert.equal(cfg.sync?.interval, -1);
+    assert.equal(cfg.sync?.initialDelay, -1);
+    assert.equal(cfg.sync?.disableForChild, true);
+  });
 });

--- a/src/__tests__/config-localpath.test.ts
+++ b/src/__tests__/config-localpath.test.ts
@@ -285,4 +285,39 @@ describe("config.localPath resolution", () => {
       fs.rmSync(other, { recursive: true, force: true });
     }
   });
+
+  it("loadConfig: sync node absent means no sync config", () => {
+    writeProjectSettings({ "pi-session-search": { localPath: tmpLocal } });
+    saveConfig({}, tmpProject);
+    const cfg = loadConfig(tmpProject);
+    assert.ok(cfg);
+    assert.equal(cfg.sync, undefined);
+  });
+
+  it("loadConfig: reads custom interval from nested sync node", () => {
+    writeProjectSettings({ "pi-session-search": { localPath: tmpLocal } });
+    saveConfig({ sync: { intervalMs: 10 * 60 * 1000 } }, tmpProject);
+    const cfg = loadConfig(tmpProject);
+    assert.ok(cfg);
+    assert.equal(cfg.sync?.intervalMs, 10 * 60 * 1000);
+  });
+
+  it("loadConfig: -1 interval preserved for disabling auto-sync", () => {
+    writeProjectSettings({ "pi-session-search": { localPath: tmpLocal } });
+    saveConfig({ sync: { intervalMs: -1 } }, tmpProject);
+    const cfg = loadConfig(tmpProject);
+    assert.ok(cfg);
+    assert.equal(cfg.sync?.intervalMs, -1);
+  });
+
+  it("loadConfig: ignores invalid sync.intervalMs and omits sync node", () => {
+    writeProjectSettings({ "pi-session-search": { localPath: tmpLocal } });
+    // Write raw JSON with a string value (not a number)
+    const configFile = getConfigPath(tmpProject);
+    fs.writeFileSync(configFile, JSON.stringify({ sync: { intervalMs: "fast" } }), "utf-8");
+    const cfg = loadConfig(tmpProject);
+    assert.ok(cfg);
+    assert.equal(cfg.sync, undefined);
+    // nullish coalesce to DEFAULT would yield 300000 — same as before
+  });
 });

--- a/src/__tests__/config-localpath.test.ts
+++ b/src/__tests__/config-localpath.test.ts
@@ -298,25 +298,25 @@ describe("config.localPath resolution", () => {
 
   it("loadConfig: reads custom interval from nested sync node", () => {
     writeProjectSettings({ "pi-session-search": { localPath: tmpLocal } });
-    saveConfig({ sync: { intervalMs: 10 * 60 * 1000 } }, tmpProject);
+    saveConfig({ sync: { interval: 10 * 60 * 1000 } }, tmpProject);
     const cfg = loadConfig(tmpProject);
     assert.ok(cfg);
-    assert.equal(cfg.sync?.intervalMs, 10 * 60 * 1000);
+    assert.equal(cfg.sync?.interval, 10 * 60 * 1000);
   });
 
   it("loadConfig: -1 interval preserved for disabling auto-sync", () => {
     writeProjectSettings({ "pi-session-search": { localPath: tmpLocal } });
-    saveConfig({ sync: { intervalMs: -1 } }, tmpProject);
+    saveConfig({ sync: { interval: -1 } }, tmpProject);
     const cfg = loadConfig(tmpProject);
     assert.ok(cfg);
-    assert.equal(cfg.sync?.intervalMs, -1);
+    assert.equal(cfg.sync?.interval, -1);
   });
 
-  it("loadConfig: ignores invalid sync.intervalMs and omits sync node", () => {
+  it("loadConfig: ignores invalid sync.interval and omits sync node", () => {
     writeProjectSettings({ "pi-session-search": { localPath: tmpLocal } });
     // Write raw JSON with a string value (not a number)
     const configFile = getConfigPath(tmpProject);
-    fs.writeFileSync(configFile, JSON.stringify({ sync: { intervalMs: "fast" } }), "utf-8");
+    fs.writeFileSync(configFile, JSON.stringify({ sync: { interval: "fast" } }), "utf-8");
     const cfg = loadConfig(tmpProject);
     assert.ok(cfg);
     assert.equal(cfg.sync, undefined);
@@ -325,10 +325,10 @@ describe("config.localPath resolution", () => {
 
   it("loadConfig: 0 interval passed through (index.ts treats 0 as invalid → fallback)", () => {
     writeProjectSettings({ "pi-session-search": { localPath: tmpLocal } });
-    saveConfig({ sync: { intervalMs: 0 } }, tmpProject);
+    saveConfig({ sync: { interval: 0 } }, tmpProject);
     const cfg = loadConfig(tmpProject);
     assert.ok(cfg);
-    assert.equal(cfg.sync?.intervalMs, 0);
+    assert.equal(cfg.sync?.interval, 0);
     // index.ts decides timer behaviour:
     //   -1 → disabled, >0 → timer, <=0 (other than -1) → warning + default
   });
@@ -341,38 +341,38 @@ describe("config.localPath resolution", () => {
     assert.equal(DEFAULT_INITIAL_DELAY_MS, 0);
   });
 
-  it("loadConfig: reads initialDelayMs from nested sync node", () => {
+  it("loadConfig: reads initialDelay from nested sync node", () => {
     writeProjectSettings({ "pi-session-search": { localPath: tmpLocal } });
-    saveConfig({ sync: { initialDelayMs: 30_000 } }, tmpProject);
+    saveConfig({ sync: { initialDelay: 30_000 } }, tmpProject);
     const cfg = loadConfig(tmpProject);
     assert.ok(cfg);
-    assert.equal(cfg.sync?.initialDelayMs, 30_000);
+    assert.equal(cfg.sync?.initialDelay, 30_000);
   });
 
-  it("loadConfig: -1 initialDelayMs preserved for skipping initial sync", () => {
+  it("loadConfig: -1 initialDelay preserved for skipping initial sync", () => {
     writeProjectSettings({ "pi-session-search": { localPath: tmpLocal } });
-    saveConfig({ sync: { initialDelayMs: -1 } }, tmpProject);
+    saveConfig({ sync: { initialDelay: -1 } }, tmpProject);
     const cfg = loadConfig(tmpProject);
     assert.ok(cfg);
-    assert.equal(cfg.sync?.initialDelayMs, -1);
+    assert.equal(cfg.sync?.initialDelay, -1);
   });
 
-  it("loadConfig: both intervalMs and initialDelayMs loaded together", () => {
+  it("loadConfig: both interval and initialDelay loaded together", () => {
     writeProjectSettings({ "pi-session-search": { localPath: tmpLocal } });
-    saveConfig({ sync: { intervalMs: 600_000, initialDelayMs: 10_000 } }, tmpProject);
+    saveConfig({ sync: { interval: 600_000, initialDelay: 10_000 } }, tmpProject);
     const cfg = loadConfig(tmpProject);
     assert.ok(cfg);
-    assert.equal(cfg.sync?.intervalMs, 600_000);
-    assert.equal(cfg.sync?.initialDelayMs, 10_000);
+    assert.equal(cfg.sync?.interval, 600_000);
+    assert.equal(cfg.sync?.initialDelay, 10_000);
   });
 
-  it("loadConfig: initialDelayMs alone (no intervalMs) still produces sync node", () => {
+  it("loadConfig: initialDelay alone (no interval) still produces sync node", () => {
     writeProjectSettings({ "pi-session-search": { localPath: tmpLocal } });
-    saveConfig({ sync: { initialDelayMs: 5_000 } }, tmpProject);
+    saveConfig({ sync: { initialDelay: 5_000 } }, tmpProject);
     const cfg = loadConfig(tmpProject);
     assert.ok(cfg);
     assert.ok(cfg.sync);
-    assert.equal(cfg.sync!.initialDelayMs, 5_000);
-    assert.equal(cfg.sync!.intervalMs, undefined);
+    assert.equal(cfg.sync!.initialDelay, 5_000);
+    assert.equal(cfg.sync!.interval, undefined);
   });
 });

--- a/src/__tests__/config-localpath.test.ts
+++ b/src/__tests__/config-localpath.test.ts
@@ -22,6 +22,7 @@ import {
   getIndexDir,
   loadConfig,
   saveConfig,
+  DEFAULT_SYNC_INTERVAL_MS,
 } from "../config";
 
 const originalHome = process.env.HOME;
@@ -319,5 +320,19 @@ describe("config.localPath resolution", () => {
     assert.ok(cfg);
     assert.equal(cfg.sync, undefined);
     // nullish coalesce to DEFAULT would yield 300000 — same as before
+  });
+
+  it("loadConfig: 0 interval passed through (index.ts treats 0 as invalid → fallback)", () => {
+    writeProjectSettings({ "pi-session-search": { localPath: tmpLocal } });
+    saveConfig({ sync: { intervalMs: 0 } }, tmpProject);
+    const cfg = loadConfig(tmpProject);
+    assert.ok(cfg);
+    assert.equal(cfg.sync?.intervalMs, 0);
+    // index.ts decides timer behaviour:
+    //   -1 → disabled, >0 → timer, <=0 (other than -1) → warning + default
+  });
+
+  it("DEFAULT_SYNC_INTERVAL_MS is exported from config module", () => {
+    assert.equal(DEFAULT_SYNC_INTERVAL_MS, 5 * 60 * 1000);
   });
 });

--- a/src/__tests__/config-localpath.test.ts
+++ b/src/__tests__/config-localpath.test.ts
@@ -23,6 +23,7 @@ import {
   loadConfig,
   saveConfig,
   DEFAULT_SYNC_INTERVAL_MS,
+  DEFAULT_INITIAL_DELAY_MS,
 } from "../config";
 
 const originalHome = process.env.HOME;
@@ -334,5 +335,44 @@ describe("config.localPath resolution", () => {
 
   it("DEFAULT_SYNC_INTERVAL_MS is exported from config module", () => {
     assert.equal(DEFAULT_SYNC_INTERVAL_MS, 5 * 60 * 1000);
+  });
+
+  it("DEFAULT_INITIAL_DELAY_MS is exported and defaults to 0", () => {
+    assert.equal(DEFAULT_INITIAL_DELAY_MS, 0);
+  });
+
+  it("loadConfig: reads initialDelayMs from nested sync node", () => {
+    writeProjectSettings({ "pi-session-search": { localPath: tmpLocal } });
+    saveConfig({ sync: { initialDelayMs: 30_000 } }, tmpProject);
+    const cfg = loadConfig(tmpProject);
+    assert.ok(cfg);
+    assert.equal(cfg.sync?.initialDelayMs, 30_000);
+  });
+
+  it("loadConfig: -1 initialDelayMs preserved for skipping initial sync", () => {
+    writeProjectSettings({ "pi-session-search": { localPath: tmpLocal } });
+    saveConfig({ sync: { initialDelayMs: -1 } }, tmpProject);
+    const cfg = loadConfig(tmpProject);
+    assert.ok(cfg);
+    assert.equal(cfg.sync?.initialDelayMs, -1);
+  });
+
+  it("loadConfig: both intervalMs and initialDelayMs loaded together", () => {
+    writeProjectSettings({ "pi-session-search": { localPath: tmpLocal } });
+    saveConfig({ sync: { intervalMs: 600_000, initialDelayMs: 10_000 } }, tmpProject);
+    const cfg = loadConfig(tmpProject);
+    assert.ok(cfg);
+    assert.equal(cfg.sync?.intervalMs, 600_000);
+    assert.equal(cfg.sync?.initialDelayMs, 10_000);
+  });
+
+  it("loadConfig: initialDelayMs alone (no intervalMs) still produces sync node", () => {
+    writeProjectSettings({ "pi-session-search": { localPath: tmpLocal } });
+    saveConfig({ sync: { initialDelayMs: 5_000 } }, tmpProject);
+    const cfg = loadConfig(tmpProject);
+    assert.ok(cfg);
+    assert.ok(cfg.sync);
+    assert.equal(cfg.sync!.initialDelayMs, 5_000);
+    assert.equal(cfg.sync!.intervalMs, undefined);
   });
 });

--- a/src/__tests__/sync-action.test.ts
+++ b/src/__tests__/sync-action.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { resolveSyncAction } from "../index";
+import { resolveSyncAction, resolveInitialSyncAction } from "../index";
 
 describe("resolveSyncAction", () => {
   it("returns disabled for -1", () => {
@@ -43,6 +43,43 @@ describe("resolveSyncAction", () => {
     const result = resolveSyncAction(undefined);
     assert.equal(result.disabled, false);
     assert.ok(result.intervalMs && result.intervalMs > 0);
+    assert.equal(result.fallback, true);
+  });
+});
+
+describe("resolveInitialSyncAction", () => {
+  it("returns skip: true for -1", () => {
+    const result = resolveInitialSyncAction(-1);
+    assert.equal(result.skip, true);
+    assert.equal(result.delayMs, undefined);
+    assert.equal(result.fallback, undefined);
+  });
+
+  it("returns immediate (delayMs: 0) for 0", () => {
+    const result = resolveInitialSyncAction(0);
+    assert.equal(result.skip, false);
+    assert.equal(result.delayMs, 0);
+    assert.equal(result.fallback, undefined);
+  });
+
+  it("returns delay for positive values", () => {
+    const result = resolveInitialSyncAction(30_000);
+    assert.equal(result.skip, false);
+    assert.equal(result.delayMs, 30_000);
+    assert.equal(result.fallback, undefined);
+  });
+
+  it("falls back to default for any negative value other than -1", () => {
+    const result = resolveInitialSyncAction(-2);
+    assert.equal(result.skip, false);
+    assert.equal(result.delayMs, 0);
+    assert.equal(result.fallback, true);
+  });
+
+  it("falls back to default when undefined (no config)", () => {
+    const result = resolveInitialSyncAction(undefined);
+    assert.equal(result.skip, false);
+    assert.equal(result.delayMs, 0);
     assert.equal(result.fallback, true);
   });
 });

--- a/src/__tests__/sync-action.test.ts
+++ b/src/__tests__/sync-action.test.ts
@@ -6,9 +6,9 @@
  * setInterval isn't scheduled when intervalMs === -1 without needing
  * a full pi runtime mock.
  */
-import { describe, it } from "node:test";
+import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { resolveSyncAction, resolveInitialSyncAction } from "../index";
+import { resolveSyncAction, resolveInitialSyncAction, isChildProcess } from "../index";
 
 describe("resolveSyncAction", () => {
   it("returns disabled for -1", () => {
@@ -81,5 +81,69 @@ describe("resolveInitialSyncAction", () => {
     assert.equal(result.skip, false);
     assert.equal(result.delayMs, 0);
     assert.equal(result.fallback, true);
+  });
+});
+
+describe("isChildProcess", () => {
+  const origDepth = process.env.PI_SUBAGENT_DEPTH;
+  const origStdinIsTty = process.stdin.isTTY;
+
+  afterEach(() => {
+    // Restore environment.
+    if (origDepth === undefined) {
+      delete process.env.PI_SUBAGENT_DEPTH;
+    } else {
+      process.env.PI_SUBAGENT_DEPTH = origDepth;
+    }
+    // Restore stdin.isTTY via Object.defineProperty (it's a getter).
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: origStdinIsTty,
+      writable: false,
+      enumerable: true,
+      configurable: true,
+    });
+  });
+
+  it("returns true when PI_SUBAGENT_DEPTH > 0", () => {
+    process.env.PI_SUBAGENT_DEPTH = "1";
+    assert.equal(isChildProcess(), true);
+  });
+
+  it("returns true when PI_SUBAGENT_DEPTH is deeply nested", () => {
+    process.env.PI_SUBAGENT_DEPTH = "3";
+    assert.equal(isChildProcess(), true);
+  });
+
+  it("returns false when PI_SUBAGENT_DEPTH is 0 and stdin is TTY", () => {
+    process.env.PI_SUBAGENT_DEPTH = "0";
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      writable: false,
+      enumerable: true,
+      configurable: true,
+    });
+    assert.equal(isChildProcess(), false);
+  });
+
+  it("returns true when stdin.isTTY is false (non-interactive)", () => {
+    delete process.env.PI_SUBAGENT_DEPTH;
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: false,
+      writable: false,
+      enumerable: true,
+      configurable: true,
+    });
+    assert.equal(isChildProcess(), true);
+  });
+
+  it("returns false when both signals are absent (normal interactive session)", () => {
+    delete process.env.PI_SUBAGENT_DEPTH;
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      writable: false,
+      enumerable: true,
+      configurable: true,
+    });
+    assert.equal(isChildProcess(), false);
   });
 });

--- a/src/__tests__/sync-action.test.ts
+++ b/src/__tests__/sync-action.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests for resolveSyncAction — the pure decision function that maps
+ * raw sync.intervalMs config values to timer behaviour.
+ *
+ * This isolates the logic from the ExtensionAPI so we can assert that
+ * setInterval isn't scheduled when intervalMs === -1 without needing
+ * a full pi runtime mock.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { resolveSyncAction } from "../index";
+
+describe("resolveSyncAction", () => {
+  it("returns disabled for -1", () => {
+    const result = resolveSyncAction(-1);
+    assert.equal(result.disabled, true);
+    assert.equal(result.intervalMs, undefined);
+    assert.equal(result.fallback, undefined);
+  });
+
+  it("returns timer interval for positive values", () => {
+    const result = resolveSyncAction(900_000);
+    assert.equal(result.disabled, false);
+    assert.equal(result.intervalMs, 900_000);
+    assert.equal(result.fallback, undefined);
+  });
+
+  it("falls back to default for 0 with warning flag", () => {
+    const result = resolveSyncAction(0);
+    assert.equal(result.disabled, false);
+    assert.ok(result.intervalMs && result.intervalMs > 0);
+    assert.equal(result.fallback, true);
+  });
+
+  it("falls back to default for any negative value other than -1", () => {
+    const result = resolveSyncAction(-2);
+    assert.equal(result.disabled, false);
+    assert.ok(result.intervalMs && result.intervalMs > 0);
+    assert.equal(result.fallback, true);
+  });
+
+  it("falls back to default when undefined (no config)", () => {
+    const result = resolveSyncAction(undefined);
+    assert.equal(result.disabled, false);
+    assert.ok(result.intervalMs && result.intervalMs > 0);
+    assert.equal(result.fallback, true);
+  });
+});

--- a/src/__tests__/sync-action.test.ts
+++ b/src/__tests__/sync-action.test.ts
@@ -39,11 +39,11 @@ describe("resolveSyncAction", () => {
     assert.equal(result.fallback, true);
   });
 
-  it("falls back to default when undefined (no config)", () => {
+  it("returns silent default when undefined (no config) — no fallback warning", () => {
     const result = resolveSyncAction(undefined);
     assert.equal(result.disabled, false);
     assert.ok(result.intervalMs && result.intervalMs > 0);
-    assert.equal(result.fallback, true);
+    assert.equal(result.fallback, undefined); // absent config must not warn
   });
 });
 
@@ -76,11 +76,11 @@ describe("resolveInitialSyncAction", () => {
     assert.equal(result.fallback, true);
   });
 
-  it("falls back to default when undefined (no config)", () => {
+  it("returns silent default when undefined (no config) — no fallback warning", () => {
     const result = resolveInitialSyncAction(undefined);
     assert.equal(result.skip, false);
     assert.equal(result.delayMs, 0);
-    assert.equal(result.fallback, true);
+    assert.equal(result.fallback, undefined); // absent config must not warn
   });
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,13 +4,19 @@ import type { EmbedderConfig } from "./embedder";
 
 // ─── Types ───────────────────────────────────────────────────────────
 
-const DEFAULT_SYNC_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+/** Default interval (ms) between automatic session index re-syncs. */
+export const DEFAULT_SYNC_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 
 /** Sync behaviour configuration. Mirrors EmbedderConfig nesting pattern. */
 export interface SyncConfig {
   /**
    * Interval (ms) between automatic session index re-syncs.
-   * Default: 300000 (5 min). Use -1 to disable background auto-sync entirely.
+   *
+   * - Positive value: sync fires every N milliseconds.
+   * - `-1`: disables periodic auto-sync entirely (initial startup sync still runs).
+   * - Any other non-positive value falls back to the default (5 min) with a warning.
+   *
+   * @default 300000 (5 minutes when sync node is absent)
    */
   intervalMs: number;
 }
@@ -31,7 +37,7 @@ export interface ConfigFile {
   extraArchiveDirs?: string[];
   /** Nested sync settings. */
   sync?: {
-    /** Interval in ms; -1 disables auto-sync. */
+    /** Interval in ms; -1 disables auto-sync; other non-positive values fall back to default. */
     intervalMs?: number;
   };
   embedder?: EmbedderConfig;

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,9 @@ import type { EmbedderConfig } from "./embedder";
 /** Default interval (ms) between automatic session index re-syncs. */
 export const DEFAULT_SYNC_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 
+/** Default delay (ms) before the initial startup sync fires (0 = immediate). */
+export const DEFAULT_INITIAL_DELAY_MS = 0;
+
 /** Sync behaviour configuration. Mirrors EmbedderConfig nesting pattern. */
 export interface SyncConfig {
   /**
@@ -18,7 +21,18 @@ export interface SyncConfig {
    *
    * @default 300000 (5 minutes when sync node is absent)
    */
-  intervalMs: number;
+  intervalMs?: number;
+  /**
+   * Delay (ms) before the initial startup sync fires after loading the index.
+   *
+   * - Positive value: wait N milliseconds before running the first sync.
+   * - `0`: run immediately (default).
+   * - `-1`: skip the initial startup sync entirely.
+   * - Any other non-positive value falls back to the default (immediate) with a warning.
+   *
+   * @default 0 (immediate)
+   */
+  initialDelayMs?: number;
 }
 
 export interface Config {
@@ -39,6 +53,8 @@ export interface ConfigFile {
   sync?: {
     /** Interval in ms; -1 disables auto-sync; other non-positive values fall back to default. */
     intervalMs?: number;
+    /** Delay in ms before initial sync; 0 = immediate, -1 = skip entirely. */
+    initialDelayMs?: number;
   };
   embedder?: EmbedderConfig;
 }
@@ -122,10 +138,12 @@ export function loadConfig(cwd?: string): Config | null {
   }
 
   const rawInterval = file.sync?.intervalMs;
+  const rawInitialDelay = file.sync?.initialDelayMs;
   let syncCfg: SyncConfig | undefined;
-  if (typeof rawInterval === "number") {
-    syncCfg = { intervalMs: rawInterval };
-  }
+  const syncFields: SyncConfig = {};
+  if (typeof rawInterval === "number") syncFields.intervalMs = rawInterval;
+  if (typeof rawInitialDelay === "number") syncFields.initialDelayMs = rawInitialDelay;
+  if (Object.keys(syncFields).length > 0) syncCfg = syncFields;
 
   return {
     extraSessionDirs: file.extraSessionDirs ?? [],

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,7 @@ export interface SyncConfig {
    *
    * @default 300000 (5 minutes when sync node is absent)
    */
-  intervalMs?: number;
+  interval?: number;
   /**
    * Delay (ms) before the initial startup sync fires after loading the index.
    *
@@ -32,7 +32,7 @@ export interface SyncConfig {
    *
    * @default 0 (immediate)
    */
-  initialDelayMs?: number;
+  initialDelay?: number;
 }
 
 export interface Config {
@@ -52,9 +52,9 @@ export interface ConfigFile {
   /** Nested sync settings. */
   sync?: {
     /** Interval in ms; -1 disables auto-sync; other non-positive values fall back to default. */
-    intervalMs?: number;
+    interval?: number;
     /** Delay in ms before initial sync; 0 = immediate, -1 = skip entirely. */
-    initialDelayMs?: number;
+    initialDelay?: number;
   };
   embedder?: EmbedderConfig;
 }
@@ -137,12 +137,12 @@ export function loadConfig(cwd?: string): Config | null {
     return null;
   }
 
-  const rawInterval = file.sync?.intervalMs;
-  const rawInitialDelay = file.sync?.initialDelayMs;
+  const rawInterval = file.sync?.interval;
+  const rawInitialDelay = file.sync?.initialDelay;
   let syncCfg: SyncConfig | undefined;
   const syncFields: SyncConfig = {};
-  if (typeof rawInterval === "number") syncFields.intervalMs = rawInterval;
-  if (typeof rawInitialDelay === "number") syncFields.initialDelayMs = rawInitialDelay;
+  if (typeof rawInterval === "number") syncFields.interval = rawInterval;
+  if (typeof rawInitialDelay === "number") syncFields.initialDelay = rawInitialDelay;
   if (Object.keys(syncFields).length > 0) syncCfg = syncFields;
 
   return {

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,21 @@ export interface SyncConfig {
    * @default 0 (immediate)
    */
   initialDelay?: number;
+  /**
+   * When true, automatically disable all sync (both initial and periodic)
+   * if this pi process is detected as a subagent child or non-interactive
+   * programmatic invocation.
+   *
+   * Detection signals (any one triggers):
+   * - `PI_SUBAGENT_DEPTH > 0` (official pi-subagents child marker)
+   * - `!process.stdin.isTTY` (non-interactive terminal)
+   *
+   * Useful for suppressing background sync in CI/CD pipelines, automated
+   * tooling, or nested agent workflows where sync would waste resources.
+   *
+   * @default false
+   */
+  disableForChild?: boolean;
 }
 
 export interface Config {
@@ -55,6 +70,8 @@ export interface ConfigFile {
     interval?: number;
     /** Delay in ms before initial sync; 0 = immediate, -1 = skip entirely. */
     initialDelay?: number;
+    /** Auto-disable sync when running as a subagent child or non-interactively. */
+    disableForChild?: boolean;
   };
   embedder?: EmbedderConfig;
 }
@@ -139,10 +156,12 @@ export function loadConfig(cwd?: string): Config | null {
 
   const rawInterval = file.sync?.interval;
   const rawInitialDelay = file.sync?.initialDelay;
+  const rawDisableForChild = file.sync?.disableForChild;
   let syncCfg: SyncConfig | undefined;
   const syncFields: SyncConfig = {};
   if (typeof rawInterval === "number") syncFields.interval = rawInterval;
   if (typeof rawInitialDelay === "number") syncFields.initialDelay = rawInitialDelay;
+  if (typeof rawDisableForChild === "boolean") syncFields.disableForChild = rawDisableForChild;
   if (Object.keys(syncFields).length > 0) syncCfg = syncFields;
 
   return {

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,11 +4,24 @@ import type { EmbedderConfig } from "./embedder";
 
 // ─── Types ───────────────────────────────────────────────────────────
 
+const DEFAULT_SYNC_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+/** Sync behaviour configuration. Mirrors EmbedderConfig nesting pattern. */
+export interface SyncConfig {
+  /**
+   * Interval (ms) between automatic session index re-syncs.
+   * Default: 300000 (5 min). Use -1 to disable background auto-sync entirely.
+   */
+  intervalMs: number;
+}
+
 export interface Config {
   /** Extra session directories to scan (in addition to default) */
   extraSessionDirs: string[];
   /** Extra archive directories to scan (in addition to default) */
   extraArchiveDirs: string[];
+  /** Optional sync configuration — controls periodic re-sync behaviour. */
+  sync?: SyncConfig;
   /** Optional embedder configuration — enables hybrid search when set */
   embedder?: EmbedderConfig;
 }
@@ -16,6 +29,11 @@ export interface Config {
 export interface ConfigFile {
   extraSessionDirs?: string[];
   extraArchiveDirs?: string[];
+  /** Nested sync settings. */
+  sync?: {
+    /** Interval in ms; -1 disables auto-sync. */
+    intervalMs?: number;
+  };
   embedder?: EmbedderConfig;
 }
 
@@ -97,9 +115,16 @@ export function loadConfig(cwd?: string): Config | null {
     return null;
   }
 
+  const rawInterval = file.sync?.intervalMs;
+  let syncCfg: SyncConfig | undefined;
+  if (typeof rawInterval === "number") {
+    syncCfg = { intervalMs: rawInterval };
+  }
+
   return {
     extraSessionDirs: file.extraSessionDirs ?? [],
     extraArchiveDirs: file.extraArchiveDirs ?? [],
+    sync: syncCfg,
     embedder: file.embedder,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,11 +8,20 @@ import {
   DEFAULT_SYNC_INTERVAL_MS,
   DEFAULT_INITIAL_DELAY_MS,
 } from "./config";
-import type { Config, ConfigFile, SyncConfig } from "./config";
+import type { Config } from "./config";
+import { createEmbedder } from "./embedder";
+import { SessionIndex } from "./session-index";
+import { FtsSessionIndex } from "./fts-index";
+import { readSessionConversation } from "./reader";
+import { resolve } from "node:path";
+import { truncate, pathToSlug, formatRelativeDate } from "./utils";
+
+type AnyIndex = SessionIndex | FtsSessionIndex;
 
 /**
  * Resolve the effective sync interval and return the timer action.
  *
+ * - `undefined` → silent default (no warning)
  * - `-1` → `{ disabled: true }` (no timer)
  * - `> 0` → `{ disabled: false, intervalMs: <value> }` (timer fires every N ms)
  * - other ≤ 0 → `{ disabled: false, intervalMs: DEFAULT, fallback: true }` (warn + default)
@@ -22,8 +31,10 @@ export function resolveSyncAction(rawInterval?: number): {
   intervalMs?: number;
   fallback?: boolean;
 } {
+  if (rawInterval === undefined)
+    return { disabled: false, intervalMs: DEFAULT_SYNC_INTERVAL_MS };
   if (rawInterval === -1) return { disabled: true };
-  if (typeof rawInterval !== "number" || rawInterval <= 0) {
+  if (rawInterval <= 0) {
     return { disabled: false, intervalMs: DEFAULT_SYNC_INTERVAL_MS, fallback: true };
   }
   return { disabled: false, intervalMs: rawInterval };
@@ -32,6 +43,7 @@ export function resolveSyncAction(rawInterval?: number): {
 /**
  * Resolve the initial startup sync delay and return the action.
  *
+ * - `undefined` → silent default immediate (no warning)
  * - `-1` → `{ skip: true }` (no initial sync)
  * - `>= 0` → `{ skip: false, delayMs: <value> }` (sync after N ms, 0 = immediate)
  * - other < 0 → `{ skip: false, delayMs: DEFAULT, fallback: true }` (warn + default)
@@ -41,8 +53,10 @@ export function resolveInitialSyncAction(rawDelay?: number): {
   delayMs?: number;
   fallback?: boolean;
 } {
+  if (rawDelay === undefined)
+    return { skip: false, delayMs: DEFAULT_INITIAL_DELAY_MS };
   if (rawDelay === -1) return { skip: true };
-  if (typeof rawDelay !== "number" || rawDelay < 0) {
+  if (rawDelay < 0) {
     return { skip: false, delayMs: DEFAULT_INITIAL_DELAY_MS, fallback: true };
   }
   return { skip: false, delayMs: rawDelay };
@@ -62,14 +76,6 @@ export function isChildProcess(): boolean {
   if (!process.stdin.isTTY) return true;
   return false;
 }
-import { createEmbedder } from "./embedder";
-import { SessionIndex } from "./session-index";
-import { FtsSessionIndex } from "./fts-index";
-import { readSessionConversation } from "./reader";
-import { resolve } from "node:path";
-import { truncate, pathToSlug, formatRelativeDate } from "./utils";
-
-type AnyIndex = SessionIndex | FtsSessionIndex;
 
 export default function (pi: ExtensionAPI) {
   let sessionIndex: AnyIndex | null = null;
@@ -204,6 +210,9 @@ export default function (pi: ExtensionAPI) {
           config?.extraArchiveDirs ?? [],
         );
       }
+
+      // Load persisted index from disk (searches work immediately; runs v2→v3 migration)
+      await sessionIndex.load();
 
       // Resolve initial sync action (skip/delay/immediate)
       const initAction = initialAction ?? resolveInitialSyncAction(DEFAULT_INITIAL_DELAY_MS);

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,7 +204,8 @@ export default function (pi: ExtensionAPI) {
           config?.extraArchiveDirs ?? [],
         );
       }
-// Resolve initial sync action (skip/delay/immediate)
+
+      // Resolve initial sync action (skip/delay/immediate)
       const initAction = initialAction ?? resolveInitialSyncAction(DEFAULT_INITIAL_DELAY_MS);
       if (initAction.skip) {
         ctx.ui.notify(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,32 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
-import { loadConfig, saveConfig, getConfigPath, getIndexDir, DEFAULT_SYNC_INTERVAL_MS } from "./config";
+import {
+  loadConfig,
+  saveConfig,
+  getConfigPath,
+  getIndexDir,
+  DEFAULT_SYNC_INTERVAL_MS,
+} from "./config";
 import type { Config, ConfigFile, SyncConfig } from "./config";
+
+/**
+ * Resolve the effective sync interval and return the timer action.
+ *
+ * - `-1` → `{ disabled: true }` (no timer)
+ * - `> 0` → `{ disabled: false, intervalMs: <value> }` (timer fires every N ms)
+ * - other ≤ 0 → `{ disabled: false, intervalMs: DEFAULT, fallback: true }` (warn + default)
+ */
+export function resolveSyncAction(rawInterval?: number): {
+  disabled: boolean;
+  intervalMs?: number;
+  fallback?: boolean;
+} {
+  if (rawInterval === -1) return { disabled: true };
+  if (typeof rawInterval !== "number" || rawInterval <= 0) {
+    return { disabled: false, intervalMs: DEFAULT_SYNC_INTERVAL_MS, fallback: true };
+  }
+  return { disabled: false, intervalMs: rawInterval };
+}
 import { createEmbedder } from "./embedder";
 import { SessionIndex } from "./session-index";
 import { FtsSessionIndex } from "./fts-index";
@@ -105,13 +130,18 @@ export default function (pi: ExtensionAPI) {
     }
 
     // Apply configurable sync interval (from nested sync.intervalMs)
-    effectiveSyncIntervalMs = currentConfig?.sync?.intervalMs ?? DEFAULT_SYNC_INTERVAL_MS;
+    const syncAction = resolveSyncAction(currentConfig?.sync?.intervalMs);
+    effectiveSyncIntervalMs = syncAction.intervalMs ?? DEFAULT_SYNC_INTERVAL_MS;
 
     // FTS5 works out of the box with no config; embeddings are optional.
-    void startIndex(currentConfig, ctx);
+    void startIndex(currentConfig, ctx, syncAction);
   });
 
-  async function startIndex(config: Config | null, ctx: any) {
+  async function startIndex(
+    config: Config | null,
+    ctx: any,
+    syncAction?: ReturnType<typeof resolveSyncAction>,
+  ) {
     try {
       if (config?.embedder) {
         const embedder = createEmbedder(config.embedder);
@@ -168,19 +198,18 @@ export default function (pi: ExtensionAPI) {
         });
 
       // Periodic background sync to pick up new/changed sessions
-      if (effectiveSyncIntervalMs === -1) {
-        // Auto-sync explicitly disabled by user.
+      const action = syncAction ?? resolveSyncAction(effectiveSyncIntervalMs);
+      if (action.disabled) {
         ctx.ui.notify("session-search: auto-sync disabled (set sync.intervalMs > 0 to re-enable)", "info");
-      } else if (effectiveSyncIntervalMs <= 0) {
-        // Invalid non-positive value (other than -1): fall back to default with warning.
+      } else if (action.fallback) {
         ctx.ui.notify(
-          `session-search: invalid sync.intervalMs (${effectiveSyncIntervalMs}), falling back to ${DEFAULT_SYNC_INTERVAL_MS / 1000}s`,
+          `session-search: invalid sync.intervalMs, falling back to ${DEFAULT_SYNC_INTERVAL_MS / 1000}s`,
           "warning",
         );
         effectiveSyncIntervalMs = DEFAULT_SYNC_INTERVAL_MS;
       }
 
-      if (effectiveSyncIntervalMs > 0) {
+      if (!action.disabled && effectiveSyncIntervalMs > 0) {
         syncTimer = setInterval(async () => {
           if (!sessionIndex || shuttingDown) return;
           try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   getConfigPath,
   getIndexDir,
   DEFAULT_SYNC_INTERVAL_MS,
+  DEFAULT_INITIAL_DELAY_MS,
 } from "./config";
 import type { Config, ConfigFile, SyncConfig } from "./config";
 
@@ -26,6 +27,25 @@ export function resolveSyncAction(rawInterval?: number): {
     return { disabled: false, intervalMs: DEFAULT_SYNC_INTERVAL_MS, fallback: true };
   }
   return { disabled: false, intervalMs: rawInterval };
+}
+
+/**
+ * Resolve the initial startup sync delay and return the action.
+ *
+ * - `-1` → `{ skip: true }` (no initial sync)
+ * - `>= 0` → `{ skip: false, delayMs: <value> }` (sync after N ms, 0 = immediate)
+ * - other < 0 → `{ skip: false, delayMs: DEFAULT, fallback: true }` (warn + default)
+ */
+export function resolveInitialSyncAction(rawDelay?: number): {
+  skip: boolean;
+  delayMs?: number;
+  fallback?: boolean;
+} {
+  if (rawDelay === -1) return { skip: true };
+  if (typeof rawDelay !== "number" || rawDelay < 0) {
+    return { skip: false, delayMs: DEFAULT_INITIAL_DELAY_MS, fallback: true };
+  }
+  return { skip: false, delayMs: rawDelay };
 }
 import { createEmbedder } from "./embedder";
 import { SessionIndex } from "./session-index";
@@ -133,14 +153,18 @@ export default function (pi: ExtensionAPI) {
     const syncAction = resolveSyncAction(currentConfig?.sync?.intervalMs);
     effectiveSyncIntervalMs = syncAction.intervalMs ?? DEFAULT_SYNC_INTERVAL_MS;
 
+    // Apply configurable initial sync delay (from nested sync.initialDelayMs)
+    const initialAction = resolveInitialSyncAction(currentConfig?.sync?.initialDelayMs);
+
     // FTS5 works out of the box with no config; embeddings are optional.
-    void startIndex(currentConfig, ctx, syncAction);
+    void startIndex(currentConfig, ctx, syncAction, initialAction);
   });
 
   async function startIndex(
     config: Config | null,
     ctx: any,
     syncAction?: ReturnType<typeof resolveSyncAction>,
+    initialAction?: ReturnType<typeof resolveInitialSyncAction>,
   ) {
     try {
       if (config?.embedder) {
@@ -158,18 +182,34 @@ export default function (pi: ExtensionAPI) {
           config?.extraArchiveDirs ?? [],
         );
       }
-      await sessionIndex.load();
+// Resolve initial sync action (skip/delay/immediate)
+      const initAction = initialAction ?? resolveInitialSyncAction(DEFAULT_INITIAL_DELAY_MS);
+      if (initAction.skip) {
+        ctx.ui.notify(
+          "session-search: initial sync skipped (set sync.initialDelayMs >= 0 to enable)",
+          "info",
+        );
+      } else if (initAction.fallback) {
+        ctx.ui.notify(
+          "session-search: invalid sync.initialDelayMs, falling back to immediate",
+          "warning",
+        );
+      }
 
       // Fire-and-forget: run initial sync in the background so startIndex
       // returns immediately and doesn't block pi's startup.
-      const SYNC_TIMEOUT_MS = 600_000;
-      Promise.race([
-        sessionIndex.sync(
-          (msg) => ctx.ui.setStatus("session-search", msg)
-        ),
-        new Promise<null>((resolve) => scheduleTimer(() => resolve(null), SYNC_TIMEOUT_MS)),
-      ])
-        .then((syncResult) => {
+      if (!initAction.skip) {
+        const SYNC_TIMEOUT_MS = 600_000;
+        const delayMs = initAction.delayMs ?? DEFAULT_INITIAL_DELAY_MS;
+        const runSync = () =>
+          Promise.race([
+            sessionIndex.sync((msg) => ctx.ui.setStatus("session-search", msg)),
+            new Promise<null>((resolve) =>
+              scheduleTimer(() => resolve(null), SYNC_TIMEOUT_MS),
+            ),
+          ]);
+
+        const handleSyncResult = (syncResult: Awaited<ReturnType<typeof runSync>>) => {
           if (shuttingDown) return;
           if (syncResult === null) {
             ctx.ui.notify("session-search: sync timed out (index may be stale)", "warning");
@@ -185,17 +225,33 @@ export default function (pi: ExtensionAPI) {
               if (moved) parts.push(`↗${moved} moved`);
               ctx.ui.setStatus(
                 "session-search",
-                `Sessions: ${parts.join(" ")} (${sessionIndex.size()} total)`
+                `Sessions: ${parts.join(" ")} (${sessionIndex.size()} total)`,
               );
               scheduleTimer(() => ctx.ui.setStatus("session-search", ""), 5000);
             }
           }
-        })
-        .catch((err) => {
-          if (shuttingDown) return;
-          ctx.ui.notify(`session-search: initial sync failed: ${err.message}`, "warning");
-          ctx.ui.setStatus("session-search", "");
-        });
+        };
+
+        if (delayMs > 0) {
+          scheduleTimer(async () => {
+            try {
+              handleSyncResult(await runSync());
+            } catch (err: any) {
+              if (shuttingDown) return;
+              ctx.ui.notify(`session-search: initial sync failed: ${err.message}`, "warning");
+              ctx.ui.setStatus("session-search", "");
+            }
+          }, delayMs);
+        } else {
+          runSync()
+            .then(handleSyncResult)
+            .catch((err: any) => {
+              if (shuttingDown) return;
+              ctx.ui.notify(`session-search: initial sync failed: ${err.message}`, "warning");
+              ctx.ui.setStatus("session-search", "");
+            });
+        }
+      }
 
       // Periodic background sync to pick up new/changed sessions
       const action = syncAction ?? resolveSyncAction(effectiveSyncIntervalMs);

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,21 @@ export function resolveInitialSyncAction(rawDelay?: number): {
   }
   return { skip: false, delayMs: rawDelay };
 }
+
+/**
+ * Detect whether this pi process is a child subagent or non-interactive
+ * programmatic invocation.
+ *
+ * Signals checked (any one triggers):
+ * - `PI_SUBAGENT_DEPTH > 0` — official pi-subagents child marker
+ * - `!process.stdin.isTTY` — non-interactive terminal (CI/CD, pipes, SDK embedders)
+ */
+export function isChildProcess(): boolean {
+  const depth = Number(process.env.PI_SUBAGENT_DEPTH);
+  if (depth > 0) return true;
+  if (!process.stdin.isTTY) return true;
+  return false;
+}
 import { createEmbedder } from "./embedder";
 import { SessionIndex } from "./session-index";
 import { FtsSessionIndex } from "./fts-index";
@@ -150,11 +165,18 @@ export default function (pi: ExtensionAPI) {
     }
 
     // Apply configurable sync interval (from nested sync.interval)
-    const syncAction = resolveSyncAction(currentConfig?.sync?.interval);
+    let syncAction = resolveSyncAction(currentConfig?.sync?.interval);
     effectiveSyncIntervalMs = syncAction.intervalMs ?? DEFAULT_SYNC_INTERVAL_MS;
 
     // Apply configurable initial sync delay (from nested sync.initialDelay)
-    const initialAction = resolveInitialSyncAction(currentConfig?.sync?.initialDelay);
+    let initialAction = resolveInitialSyncAction(currentConfig?.sync?.initialDelay);
+
+    // Auto-disable for child processes if configured
+    if (currentConfig?.sync?.disableForChild && isChildProcess()) {
+      syncAction = { disabled: true };
+      initialAction = { skip: true };
+      ctx.ui.notify("session-search: sync auto-disabled (child process detected)", "info");
+    }
 
     // FTS5 works out of the box with no config; embeddings are optional.
     void startIndex(currentConfig, ctx, syncAction, initialAction);

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,12 +149,12 @@ export default function (pi: ExtensionAPI) {
       ctx.ui.notify(`session-search: ${err.message}`, "warning");
     }
 
-    // Apply configurable sync interval (from nested sync.intervalMs)
-    const syncAction = resolveSyncAction(currentConfig?.sync?.intervalMs);
+    // Apply configurable sync interval (from nested sync.interval)
+    const syncAction = resolveSyncAction(currentConfig?.sync?.interval);
     effectiveSyncIntervalMs = syncAction.intervalMs ?? DEFAULT_SYNC_INTERVAL_MS;
 
-    // Apply configurable initial sync delay (from nested sync.initialDelayMs)
-    const initialAction = resolveInitialSyncAction(currentConfig?.sync?.initialDelayMs);
+    // Apply configurable initial sync delay (from nested sync.initialDelay)
+    const initialAction = resolveInitialSyncAction(currentConfig?.sync?.initialDelay);
 
     // FTS5 works out of the box with no config; embeddings are optional.
     void startIndex(currentConfig, ctx, syncAction, initialAction);
@@ -186,12 +186,12 @@ export default function (pi: ExtensionAPI) {
       const initAction = initialAction ?? resolveInitialSyncAction(DEFAULT_INITIAL_DELAY_MS);
       if (initAction.skip) {
         ctx.ui.notify(
-          "session-search: initial sync skipped (set sync.initialDelayMs >= 0 to enable)",
+          "session-search: initial sync skipped (set sync.initialDelay >= 0 to enable)",
           "info",
         );
       } else if (initAction.fallback) {
         ctx.ui.notify(
-          "session-search: invalid sync.initialDelayMs, falling back to immediate",
+          "session-search: invalid sync.initialDelay, falling back to immediate",
           "warning",
         );
       }
@@ -256,10 +256,10 @@ export default function (pi: ExtensionAPI) {
       // Periodic background sync to pick up new/changed sessions
       const action = syncAction ?? resolveSyncAction(effectiveSyncIntervalMs);
       if (action.disabled) {
-        ctx.ui.notify("session-search: auto-sync disabled (set sync.intervalMs > 0 to re-enable)", "info");
+        ctx.ui.notify("session-search: auto-sync disabled (set sync.interval > 0 to re-enable)", "info");
       } else if (action.fallback) {
         ctx.ui.notify(
-          `session-search: invalid sync.intervalMs, falling back to ${DEFAULT_SYNC_INTERVAL_MS / 1000}s`,
+          `session-search: invalid sync.interval, falling back to ${DEFAULT_SYNC_INTERVAL_MS / 1000}s`,
           "warning",
         );
         effectiveSyncIntervalMs = DEFAULT_SYNC_INTERVAL_MS;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
-import { loadConfig, saveConfig, getConfigPath, getIndexDir } from "./config";
+import { loadConfig, saveConfig, getConfigPath, getIndexDir, DEFAULT_SYNC_INTERVAL_MS } from "./config";
 import type { Config, ConfigFile, SyncConfig } from "./config";
 import { createEmbedder } from "./embedder";
 import { SessionIndex } from "./session-index";
@@ -42,8 +42,7 @@ export default function (pi: ExtensionAPI) {
     return handle;
   }
 
-  // resolved from config at session_start; -1 means auto-sync disabled
-  const DEFAULT_SYNC_INTERVAL_MS = 5 * 60 * 1000;
+  // Resolved from config at session_start; -1 means auto-sync disabled.
   let effectiveSyncIntervalMs = DEFAULT_SYNC_INTERVAL_MS;
 
   // ------------------------------------------------------------------
@@ -105,7 +104,7 @@ export default function (pi: ExtensionAPI) {
       ctx.ui.notify(`session-search: ${err.message}`, "warning");
     }
 
-      // Apply configurable sync interval (from nested sync.intervalMs)
+    // Apply configurable sync interval (from nested sync.intervalMs)
     effectiveSyncIntervalMs = currentConfig?.sync?.intervalMs ?? DEFAULT_SYNC_INTERVAL_MS;
 
     // FTS5 works out of the box with no config; embeddings are optional.
@@ -169,7 +168,18 @@ export default function (pi: ExtensionAPI) {
         });
 
       // Periodic background sync to pick up new/changed sessions
-      // (skipped when effectiveSyncIntervalMs is -1, i.e. auto-sync disabled)
+      if (effectiveSyncIntervalMs === -1) {
+        // Auto-sync explicitly disabled by user.
+        ctx.ui.notify("session-search: auto-sync disabled (set sync.intervalMs > 0 to re-enable)", "info");
+      } else if (effectiveSyncIntervalMs <= 0) {
+        // Invalid non-positive value (other than -1): fall back to default with warning.
+        ctx.ui.notify(
+          `session-search: invalid sync.intervalMs (${effectiveSyncIntervalMs}), falling back to ${DEFAULT_SYNC_INTERVAL_MS / 1000}s`,
+          "warning",
+        );
+        effectiveSyncIntervalMs = DEFAULT_SYNC_INTERVAL_MS;
+      }
+
       if (effectiveSyncIntervalMs > 0) {
         syncTimer = setInterval(async () => {
           if (!sessionIndex || shuttingDown) return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { loadConfig, saveConfig, getConfigPath, getIndexDir } from "./config";
-import type { Config } from "./config";
+import type { Config, ConfigFile, SyncConfig } from "./config";
 import { createEmbedder } from "./embedder";
 import { SessionIndex } from "./session-index";
 import { FtsSessionIndex } from "./fts-index";
@@ -42,7 +42,9 @@ export default function (pi: ExtensionAPI) {
     return handle;
   }
 
-  const SYNC_INTERVAL_MS = 5 * 60 * 1000; // re-sync every 5 minutes
+  // resolved from config at session_start; -1 means auto-sync disabled
+  const DEFAULT_SYNC_INTERVAL_MS = 5 * 60 * 1000;
+  let effectiveSyncIntervalMs = DEFAULT_SYNC_INTERVAL_MS;
 
   // ------------------------------------------------------------------
   // Lifecycle
@@ -102,6 +104,9 @@ export default function (pi: ExtensionAPI) {
     } catch (err: any) {
       ctx.ui.notify(`session-search: ${err.message}`, "warning");
     }
+
+      // Apply configurable sync interval (from nested sync.intervalMs)
+    effectiveSyncIntervalMs = currentConfig?.sync?.intervalMs ?? DEFAULT_SYNC_INTERVAL_MS;
 
     // FTS5 works out of the box with no config; embeddings are optional.
     void startIndex(currentConfig, ctx);
@@ -164,28 +169,31 @@ export default function (pi: ExtensionAPI) {
         });
 
       // Periodic background sync to pick up new/changed sessions
-      syncTimer = setInterval(async () => {
-        if (!sessionIndex || shuttingDown) return;
-        try {
-          const result = await sessionIndex.sync();
-          if (shuttingDown) return;
-          const changes = result.added + result.updated + result.removed + result.moved;
-          if (changes > 0) {
-            const parts = [];
-            if (result.added) parts.push(`+${result.added}`);
-            if (result.updated) parts.push(`~${result.updated}`);
-            if (result.removed) parts.push(`-${result.removed}`);
-            if (result.moved) parts.push(`↗${result.moved} moved`);
-            ctx.ui.setStatus(
-              "session-search",
-              `Sessions synced: ${parts.join(" ")} (${sessionIndex.size()} total)`
-            );
-            scheduleTimer(() => ctx.ui.setStatus("session-search", ""), 5000);
+      // (skipped when effectiveSyncIntervalMs is -1, i.e. auto-sync disabled)
+      if (effectiveSyncIntervalMs > 0) {
+        syncTimer = setInterval(async () => {
+          if (!sessionIndex || shuttingDown) return;
+          try {
+            const result = await sessionIndex.sync();
+            if (shuttingDown) return;
+            const changes = result.added + result.updated + result.removed + result.moved;
+            if (changes > 0) {
+              const parts = [];
+              if (result.added) parts.push(`+${result.added}`);
+              if (result.updated) parts.push(`~${result.updated}`);
+              if (result.removed) parts.push(`-${result.removed}`);
+              if (result.moved) parts.push(`↗${result.moved} moved`);
+              ctx.ui.setStatus(
+                "session-search",
+                `Sessions synced: ${parts.join(" ")} (${sessionIndex.size()} total)`
+              );
+              scheduleTimer(() => ctx.ui.setStatus("session-search", ""), 5000);
+            }
+          } catch {
+            // Silent — don't spam on background sync failures
           }
-        } catch {
-          // Silent — don't spam on background sync failures
-        }
-      }, SYNC_INTERVAL_MS);
+        }, effectiveSyncIntervalMs);
+      }
     } catch (err: any) {
       ctx.ui.notify(`session-search init failed: ${err.message}`, "error");
     }


### PR DESCRIPTION
# The Problem
The session index auto-sync interval was hardcoded at 5 minutes with no way to configure it or disable background syncing entirely if the user wished to do it manually.  On local hosts using llama swap or similar model orchestrators on a single GPU, this slows down chat considerably and affects the user experience as well.  Would like to offer the user options on this, or allow them to sync manually by triggering the command if they wish, and allow them to limit swapping out their chat model in the middle of turns by increasing the interval (for local LLM users)

# The Solution
- Move sync settings into a nested sync config node (sync.intervalMs), matching the existing embedder pattern
- Support -1 for intervalMs to disable periodic auto-sync (initial startup sync still runs)
- Default remains 5 minutes when the sync node is absent (backward compatible)
## Config examples:
```json
// Custom 15-minute interval
{ "sync": { "intervalMs": 900000 } }
// Disable auto-sync entirely
{ "sync": { "intervalMs": -1 } }
```
# How to Test
1. Add `"sync": { "intervalMs": 900000 }` to `~/.pi/session-search/config.json` — verify sync fires every 15 min instead of 5 
2. Set `"sync": { "intervalMs": -1 }` — verify no periodic sync occurs after startup
3. Omit the sync node entirely — verify default 5-minute behavior is unchanged
4. Run tests: `node --test --import tsx src/**/*.test.ts` (69 passing)